### PR TITLE
feat(VER-2655): Improve PocketIC release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,11 @@ PocketIC is a canister smart contract testing solution for the [Internet Compute
 
 
 ## Download the PocketIC Server
-You can find the versions of the PocketIC server below.
-Note that older versions might not be available 6 months after they have been released.
+You can find the versions of the PocketIC server under the [Releases](https://github.com/dfinity/pocketic/releases) tab on the right.
+For macOS, choose `pocket-ic-x86_64-darwin.gz`, for Linux, choose `pocket-ic-x86_64-linux.gz`.
 
-| Version   | Release Date | Linux  | macOS	| Changes |
-|---        |---           |---     |---    |---      |
-| 2.0.1	    | 2023-11-23   | [download](https://download.dfinity.systems/ic/69e1408347723dbaa7a6cd2faa9b65c42abbe861/openssl-static-binaries/x86_64-linux/pocket-ic.gz) | [download](https://download.dfinity.systems/ic/69e1408347723dbaa7a6cd2faa9b65c42abbe861/openssl-static-binaries/x86_64-darwin/pocket-ic.gz) | [CHANGELOG.md](CHANGELOG.md#201---2023-11-23) |
-| 2.0.0	    | 2023-11-21   | [download](https://download.dfinity.systems/ic/29ec86dc9f9ca4691d4d4386c8b2aa41e14d9d16/openssl-static-binaries/x86_64-linux/pocket-ic.gz) | [download](https://download.dfinity.systems/ic/29ec86dc9f9ca4691d4d4386c8b2aa41e14d9d16/openssl-static-binaries/x86_64-darwin/pocket-ic.gz) | [CHANGELOG.md](CHANGELOG.md#200---2023-11-21) |
-| 1.0.0	    | 2023-10-12   | [download](https://download.dfinity.systems/ic/307d5847c1d2fe1f5e19181c7d0fcec23f4658b3/openssl-static-binaries/x86_64-linux/pocket-ic.gz) | [download](https://download.dfinity.systems/ic/307d5847c1d2fe1f5e19181c7d0fcec23f4658b3/openssl-static-binaries/x86_64-darwin/pocket-ic.gz) | [CHANGELOG.md](CHANGELOG.md#100---2023-10-12)|
-| 0.1.0	    | 2023-08-31   | [download](https://download.dfinity.systems/ic/865a816108b31956bd449282e5803ce40007789f/openssl-static-binaries/x86_64-linux/pocket-ic.gz) | [download](https://download.dfinity.systems/ic/865a816108b31956bd449282e5803ce40007789f/openssl-static-binaries/x86_64-darwin/pocket-ic.gz) | [CHANGELOG.md](CHANGELOG.md#010---2023-08-31)|
+Save the downloaded file as `pocket-ic.gz`, decompress it, and make it executable:
 
-After downloading the binary, unzip the downloaded file and make it executable:
 ```bash
 gzip -d pocket-ic.gz
 chmod +x pocket-ic


### PR DESCRIPTION
- PocketIC releases are now available under the releases tab on GitHub
- The links do not expire after 6 months
- The commit hashes are abstracted away from the user
- Download links are cleaner, and we have a link to download the latest version