### PR TITLE
Revert "chore: update PocketIC GitHub action to v9.0.2 (#37)"

### DIFF
--- a/.github/workflows/pocket-ic-server-action-test.yml
+++ b/.github/workflows/pocket-ic-server-action-test.yml
@@ -19,9 +19,9 @@ jobs:
             expected-version: '5.0.0'
             os: macos-latest
 
-          - expected-version: '9.0.2'
+          - expected-version: '9.0.1'
             os: ubuntu-latest
-          - expected-version: '9.0.2'
+          - expected-version: '9.0.1'
             os: macos-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can specify a particular version of the PocketIC server to install using the
     - name: Install PocketIC server
       uses: dfinity/pocketic@main
       with: 
-        pocket-ic-server-version: "9.0.2"
+        pocket-ic-server-version: "9.0.1"
 ```
 
 ## Download the PocketIC Server

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: >
       The PocketIC server version to install.
       If omitted, the latest version will be installed.
-    default: '9.0.2'
+    default: '9.0.1'
 
 runs:
   using: composite


### PR DESCRIPTION
This reverts commit 4ee565352e5429c40064377ecba52023405d3327.