### PR TITLE
feat: support x86_64 and arm64 CPU and download.dfinity.systems in action.yml

### DIFF
--- a/.github/workflows/pocket-ic-server-action-test.yml
+++ b/.github/workflows/pocket-ic-server-action-test.yml
@@ -22,7 +22,9 @@ jobs:
           - expected-version: '9.0.3'
             os: ubuntu-latest
           - expected-version: '9.0.3'
-            os: macos-latest
+            os: macos-13 # x86_64
+          - expected-version: '9.0.3'
+            os: macos-latest # arm64
 
     steps:
       - name: Checkout
@@ -42,7 +44,7 @@ jobs:
           expected_pocket_ic_server_ver="pocket-ic-server ${{ matrix.expected-version }}"
 
           if [ "$actual_pocket_ic_server_ver" != "$expected_pocket_ic_server_ver" ]; then
-            echo "Error: expected PocketIC server version '$expected_pocket_ic_server_ver', but '$actual_pocket_ic_server_ver' found"
+            echo "Error: expected PocketIC server version '$expected_pocket_ic_server_ver', but got '$actual_pocket_ic_server_ver'"
             exit 1
           fi
           echo "PocketIC server version '$actual_pocket_ic_server_ver' was installed correctly"

--- a/.github/workflows/pocket-ic-server-action-test.yml
+++ b/.github/workflows/pocket-ic-server-action-test.yml
@@ -26,13 +26,13 @@ jobs:
           - expected-version: '9.0.3'
             os: macos-latest # arm64
 
-          - version: '9152ba15ab6cc3c12eb407e13f8ee483a1d5723c'
+          - version: 'ee4c728d94b10437f41edf564650ac63cd0c0c5d'
             expected-version: '10.0.0'
             os: ubuntu-latest
-          - version: '9152ba15ab6cc3c12eb407e13f8ee483a1d5723c'
+          - version: 'ee4c728d94b10437f41edf564650ac63cd0c0c5d'
             expected-version: '10.0.0'
             os: macos-13 # x86_64
-          - version: '9152ba15ab6cc3c12eb407e13f8ee483a1d5723c'
+          - version: 'ee4c728d94b10437f41edf564650ac63cd0c0c5d'
             expected-version: '10.0.0'
             os: macos-latest # arm64
 

--- a/.github/workflows/pocket-ic-server-action-test.yml
+++ b/.github/workflows/pocket-ic-server-action-test.yml
@@ -17,7 +17,7 @@ jobs:
             os: ubuntu-latest
           - version: '5.0.0'
             expected-version: '5.0.0'
-            os: macos-latest
+            os: macos-13 # x86_64
 
           - expected-version: '9.0.3'
             os: ubuntu-latest

--- a/.github/workflows/pocket-ic-server-action-test.yml
+++ b/.github/workflows/pocket-ic-server-action-test.yml
@@ -26,6 +26,16 @@ jobs:
           - expected-version: '9.0.3'
             os: macos-latest # arm64
 
+          - version: '9152ba15ab6cc3c12eb407e13f8ee483a1d5723c'
+            expected-version: '10.0.0'
+            os: ubuntu-latest
+          - version: '9152ba15ab6cc3c12eb407e13f8ee483a1d5723c'
+            expected-version: '10.0.0'
+            os: macos-13 # x86_64
+          - version: '9152ba15ab6cc3c12eb407e13f8ee483a1d5723c'
+            expected-version: '10.0.0'
+            os: macos-latest # arm64
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,8 @@ runs:
           exit 1
         fi
 
+        # if `${POCKET_IC_VERSION}` is a git hash, then use CDN;
+        # otherwise use a GitHub release.
         if [[ "${POCKET_IC_VERSION}" =~ ^[0-9a-f]{40,40}$ ]]; then
           URL="https://download.dfinity.systems/ic/${POCKET_IC_VERSION}/binaries/${ARCH}-${OS}/pocket-ic.gz"
         else

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,11 @@ runs:
         echo "OS is $OS"
         echo "ARCH is $ARCH"
 
-        URL="https://github.com/dfinity/pocketic/releases/download/${POCKET_IC_VERSION}/pocket-ic-${ARCH}-${OS}.gz"
+        if [[ "${POCKET_IC_VERSION}" =~ ^[0-9a-f]{40,40}$ ]]; then
+          URL="https://download.dfinity.systems/ic/${POCKET_IC_VERSION}/binaries/${ARCH}-${OS}/pocket-ic.gz"
+        else
+          URL="https://github.com/dfinity/pocketic/releases/download/${POCKET_IC_VERSION}/pocket-ic-${ARCH}-${OS}.gz"
+        fi
 
         # Retry up to 10 times. Each attempt has 20 seconds total to complete, 5 seconds of which is to connect.
         # This uses the default retry delay, which starts at 1s and doubles each time, up to 10 min.

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ runs:
   using: composite
   steps:
     - name: Install PocketIC server
-      shell: sh
+      shell: bash
       run: |
         export POCKET_IC_VERSION="${{ inputs.pocket-ic-server-version }}"
 

--- a/action.yml
+++ b/action.yml
@@ -26,11 +26,23 @@ runs:
           exit 1
         fi
 
+        if [ "${{ runner.arch }}" = 'X64' ]; then
+          export ARCH="x86_64"
+        elif [ "${{ runner.arch }}" = 'ARM64' ]; then
+          export ARCH="arm64"
+        else
+          echo "Unsupported CPU architecture."
+          exit 1
+        fi
+
         echo "OS is $OS"
+        echo "ARCH is $ARCH"
+
+        URL="https://github.com/dfinity/pocketic/releases/download/${POCKET_IC_VERSION}/pocket-ic-${ARCH}-${OS}.gz"
 
         # Retry up to 10 times. Each attempt has 20 seconds total to complete, 5 seconds of which is to connect.
         # This uses the default retry delay, which starts at 1s and doubles each time, up to 10 min.
-        if $(curl --fail --silent --show-error --location --retry 10 --connect-timeout 5 --max-time 20 --retry-connrefused https://github.com/dfinity/pocketic/releases/download/${POCKET_IC_VERSION}/pocket-ic-x86_64-${OS}.gz -o pocket-ic.gz); then
+        if $(curl --fail --silent --show-error --location --retry 10 --connect-timeout 5 --max-time 20 --retry-connrefused "${URL}" -o pocket-ic.gz); then
           echo "Successfully downloaded PocketIC server."
         else
           echo "Failed to download PocketIC server."

--- a/action.yml
+++ b/action.yml
@@ -35,14 +35,15 @@ runs:
           exit 1
         fi
 
-        echo "OS is $OS"
-        echo "ARCH is $ARCH"
-
         if [[ "${POCKET_IC_VERSION}" =~ ^[0-9a-f]{40,40}$ ]]; then
           URL="https://download.dfinity.systems/ic/${POCKET_IC_VERSION}/binaries/${ARCH}-${OS}/pocket-ic.gz"
         else
           URL="https://github.com/dfinity/pocketic/releases/download/${POCKET_IC_VERSION}/pocket-ic-${ARCH}-${OS}.gz"
         fi
+
+        echo "OS is $OS"
+        echo "ARCH is $ARCH"
+        echo "URL is $URL"
 
         # Retry up to 10 times. Each attempt has 20 seconds total to complete, 5 seconds of which is to connect.
         # This uses the default retry delay, which starts at 1s and doubles each time, up to 10 min.


### PR DESCRIPTION
This PR generalizes `action.yml` to
- distinguish between x86_64 and arm64 CPU architectures;
- support git hashes as `pocket-ic-version` to download PocketIC from download.dfinity.systems CDN.